### PR TITLE
fix: disable 30-minute auto-suspend

### DIFF
--- a/files/system/etc/skel/.config/hypr/hypridle.conf
+++ b/files/system/etc/skel/.config/hypr/hypridle.conf
@@ -15,7 +15,7 @@ listener {
     on-resume = hyprctl dispatch dpms on         # screen on when activity is detected after timeout has fired
 }
 
-listener {
-    timeout = 1800                               # 30min
-    on-timeout = systemctl suspend                # suspend pc
-}
+# listener {
+#     timeout = 1800                               # 30min
+#     on-timeout = systemctl suspend                # suspend pc
+# }


### PR DESCRIPTION
Disables the 30-minute idle timeout in hypridle to prevent the system from entering a sleep state that it cannot wake from.