### PR TITLE
feat: use @go-sig/golang-rawhide COPR for latest Go version

### DIFF
--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -19,7 +19,7 @@ modules:
         - atim/starship
         - chronoscrat/devpod
         - a-zhn/ghostty
-        - solopasha/hyprland
+        - sdegler/hyprland
         - erikreider/SwayNotificationCenter
         - "@go-sig/golang-rawhide"
     install:

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -29,7 +29,6 @@ modules:
         - emacs
         - devpod
         - hyprland
-        - hyprland-qtutils
         - hypridle
         - hyprlock
         - swaybg

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -21,6 +21,7 @@ modules:
         - a-zhn/ghostty
         - solopasha/hyprland
         - erikreider/SwayNotificationCenter
+        - "@go-sig/golang-rawhide"
     install:
       packages:
         - micro


### PR DESCRIPTION
This PR adds the @go-sig/golang-rawhide COPR to the dnf module in the recipe. This ensures that the OS image is built with the latest available version of Go (1.26.x as of April 2026), satisfying the requirement for the 'very latest' version.